### PR TITLE
Persist state to localstorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "react-router-dom": "^6.0.2",
     "react-use": "^17.3.2",
     "redux": "^4.1.2",
+    "redux-persist": "^6.0.0",
     "regenerator-runtime": "~0.13.9",
     "typescript": "^4.5.2"
   },

--- a/src/components/Modal/Action.tsx
+++ b/src/components/Modal/Action.tsx
@@ -46,7 +46,6 @@ export default function Action({ maxBorrowAmount, healthFactor, displaySymbol })
 
   const handleActionButtonClick = async () => {
     setLoading(true);
-    dispatch(hideModal());
     trackActionButton(action, {
       tokenId,
       amount,
@@ -114,6 +113,7 @@ export default function Action({ maxBorrowAmount, healthFactor, displaySymbol })
       default:
         break;
     }
+    dispatch(hideModal());
   };
 
   const actionDisabled = useMemo(() => {

--- a/src/components/Modal/Action.tsx
+++ b/src/components/Modal/Action.tsx
@@ -3,7 +3,7 @@ import { Box, Typography, Switch } from "@mui/material";
 import LoadingButton from "@mui/lab/LoadingButton";
 
 import { nearTokenId } from "../../utils";
-import { toggleUseAsCollateral } from "../../redux/appSlice";
+import { toggleUseAsCollateral, hideModal } from "../../redux/appSlice";
 import { actionMapTitle, getModalData } from "./utils";
 import { repay } from "../../store/actions/repay";
 import { supply } from "../../store/actions/supply";
@@ -46,6 +46,7 @@ export default function Action({ maxBorrowAmount, healthFactor, displaySymbol })
 
   const handleActionButtonClick = async () => {
     setLoading(true);
+    dispatch(hideModal());
     trackActionButton(action, {
       tokenId,
       amount,
@@ -136,7 +137,7 @@ export default function Action({ maxBorrowAmount, healthFactor, displaySymbol })
           <Typography variant="body1" fontSize="0.85rem">
             Use as Collateral
           </Typography>
-          <Switch onChange={handleSwitchToggle} />
+          <Switch onChange={handleSwitchToggle} checked={useAsCollateral} />
         </Box>
       )}
       <Box display="flex" justifyContent="center">

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,21 +2,24 @@ import dotenv from "dotenv";
 import ReactDOM from "react-dom";
 import { ThemeProvider } from "@mui/material/styles";
 import { Provider } from "react-redux";
+import { PersistGate } from "redux-persist/integration/react";
 
 import App from "./App";
 import { Modal } from "./components";
 import theme from "./theme";
-import { store } from "./redux/store";
+import { store, persistor } from "./redux/store";
 import "./global.css";
 
 dotenv.config();
 
 ReactDOM.render(
   <Provider store={store}>
-    <ThemeProvider theme={theme}>
-      <App />
-      <Modal />
-    </ThemeProvider>
+    <PersistGate loading={null} persistor={persistor}>
+      <ThemeProvider theme={theme}>
+        <App />
+        <Modal />
+      </ThemeProvider>
+    </PersistGate>
   </Provider>,
   document.querySelector("#root"),
 );

--- a/src/redux/accountSelectors.ts
+++ b/src/redux/accountSelectors.ts
@@ -442,7 +442,7 @@ export const recomputeHealthFactorRepay = (tokenId: string, amount: number) =>
     (state: RootState) => state.account,
     (assets, account) => {
       if (!hasAssets(assets)) return 0;
-      if (!account.portfolio || !tokenId) return 0;
+      if (!account.portfolio || !tokenId || !account.portfolio.borrowed[tokenId]) return 0;
 
       const collateralSum = getCollateralSum(assets.data, account);
       const { metadata, config } = assets.data[tokenId];

--- a/src/redux/appSlice.ts
+++ b/src/redux/appSlice.ts
@@ -61,7 +61,7 @@ export const appSlice = createSlice({
       state,
       action: PayloadAction<{ action: TokenAction; amount: number; tokenId: string }>,
     ) {
-      state.selected = { useAsCollateral: false, isMax: false, ...action.payload };
+      state.selected = { ...state.selected, isMax: false, ...action.payload };
       state.showModal = true;
     },
     updateAmount(state, action: PayloadAction<{ amount: number; isMax: boolean }>) {

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,16 +1,45 @@
+import { combineReducers } from "redux";
 import { configureStore } from "@reduxjs/toolkit";
+import {
+  persistStore,
+  persistReducer,
+  FLUSH,
+  REHYDRATE,
+  PAUSE,
+  PERSIST,
+  PURGE,
+  REGISTER,
+} from "redux-persist";
+import storage from "redux-persist/lib/storage";
 
 import assetsReducer from "./assetsSlice";
 import accountReducer from "./accountSlice";
 import appReducer from "./appSlice";
 
-export const store = configureStore({
-  reducer: {
-    assets: assetsReducer,
-    account: accountReducer,
-    app: appReducer,
-  },
+const persistConfig = {
+  key: "root",
+  storage,
+};
+
+const rootReducer = combineReducers({
+  assets: assetsReducer,
+  account: accountReducer,
+  app: appReducer,
 });
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+
+export const store = configureStore({
+  reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: {
+        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+      },
+    }),
+});
+
+export const persistor = persistStore(store);
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8518,6 +8518,11 @@ readable-stream@^3.0.0, readable-stream@^3.1.1, readable-stream@^3.4.0, readable
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
+
 redux-thunk@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"


### PR DESCRIPTION
Added redux-persist to save the app state to local storage.

As a side effect, it will fix #250 because once a deposit is done with the toggle as collateral enable, on the next deposits the toggle will be on. This will be persisted on page refresh or new tabs.

The account menu settings will be also persisted between page refreshes (useful to have the same settings on when returning from near wallet)



