### PR TITLE
Fix non-farmed assets popup issue for existing assets

### DIFF
--- a/src/redux/accountSlice.ts
+++ b/src/redux/accountSlice.ts
@@ -3,7 +3,7 @@ import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import { getAssetsDetailed } from "../store";
 import { getBurrow } from "../utils";
 import { getBalance, getPortfolio } from "../api";
-import { listToMap, transformAccountFarms } from "./utils";
+import { hasZeroSharesFarmRewards, listToMap, transformAccountFarms } from "./utils";
 import { ChangeMethodsLogic, IBoosterStaking } from "../interfaces";
 import { identifyUser } from "../telemetry";
 
@@ -160,7 +160,7 @@ export const accountSlice = createSlice({
           collateral: listToMap(collateral),
           farms: transformAccountFarms(farms),
           staking: booster_staking || initialStaking,
-          hasNonFarmedAssets: portfolio["has_non_farmed_assets"],
+          hasNonFarmedAssets: portfolio["has_non_farmed_assets"] || hasZeroSharesFarmRewards(farms),
         };
       }
     });

--- a/src/redux/utils.ts
+++ b/src/redux/utils.ts
@@ -78,6 +78,10 @@ export const emptyBorrowedAsset = (asset: { borrowed: number }): boolean =>
     (0).toLocaleString(undefined, TOKEN_FORMAT)
   );
 
+export const hasZeroSharesFarmRewards = (farms): boolean => {
+  return farms.some((farm) => farm["rewards"].some((reward) => reward["boosted_shares"] === "0"));
+};
+
 export const transformAsset = (
   asset: Asset,
   account: AccountState,


### PR DESCRIPTION
When there is an asset that contains a farming reward already, but a new farming reward with different token is added, the flag `has_non_farmed_assets` is returned as `false` by the contract, while it should be `true`. This PR fixes this issue.