### PR TITLE
rewardPerDay precision fix

### DIFF
--- a/src/redux/selectors/getPortfolioAssets.ts
+++ b/src/redux/selectors/getPortfolioAssets.ts
@@ -16,7 +16,7 @@ export const getPortfolioRewards = (
   if (!farm) return [];
   return Object.entries(farm).map(([tokenId, rewards]) => {
     const assetDecimals = asset.metadata.decimals + asset.config.extra_decimals;
-    const reardTokendecimals =
+    const rewardTokenDecimals =
       assets[tokenId].metadata.decimals + assets[tokenId].config.extra_decimals;
 
     const totalRewardsPerDay = Number(
@@ -26,13 +26,13 @@ export const getPortfolioRewards = (
       shrinkToken(asset.farms[type][tokenId]?.["boosted_shares"] || "0", assetDecimals),
     );
     const boostedShares = Number(
-      shrinkToken(farm?.[tokenId]?.boosted_shares || "0", reardTokendecimals),
+      shrinkToken(farm?.[tokenId]?.boosted_shares || "0", assetDecimals),
     );
 
     const rewardPerDay = (boostedShares / totalBoostedShares) * totalRewardsPerDay || 0;
 
     return {
-      rewards: { ...rewards, reward_per_day: expandToken(rewardPerDay, reardTokendecimals) },
+      rewards: { ...rewards, reward_per_day: expandToken(rewardPerDay, rewardTokenDecimals) },
       metadata: assets[tokenId].metadata,
       config: assets[tokenId].config,
       type: "portfolio",

--- a/src/redux/selectors/getPortfolioAssets.ts
+++ b/src/redux/selectors/getPortfolioAssets.ts
@@ -20,7 +20,7 @@ export const getPortfolioRewards = (
       assets[tokenId].metadata.decimals + assets[tokenId].config.extra_decimals;
 
     const totalRewardsPerDay = Number(
-      shrinkToken(asset.farms[type][tokenId]?.["reward_per_day"] || "0", assetDecimals),
+      shrinkToken(asset.farms[type][tokenId]?.["reward_per_day"] || "0", rewardTokenDecimals),
     );
     const totalBoostedShares = Number(
       shrinkToken(asset.farms[type][tokenId]?.["boosted_shares"] || "0", assetDecimals),


### PR DESCRIPTION
Came across this mismatch for precision on shares in the rewardPerDay calculation. 

I believe the `boostedShares` should be measured against asset decimals of the underlying farm and not the reward token's decimals. I think this may have gone under the radar because most assets are using 18 decimals, and Burrow pads extra decimals for small decimal tokens like `USDC`, but this could be an issue for inflating or deflating a user's share if the asset token has 24 decimals and reward token has 18 decimals. 