### PR TITLE
Rewards Per Day Fix

### DIFF
--- a/src/components/Header/stats/rewards.tsx
+++ b/src/components/Header/stats/rewards.tsx
@@ -1,9 +1,11 @@
 import { useRewards } from "../../../hooks/useRewards";
+import { IPortfolioReward } from "../../../redux/selectors/getAccountRewards";
+
 import { TOKEN_FORMAT, USD_FORMAT, NUMBER_FORMAT } from "../../../store";
 import { Stat } from "./components";
 
-const transformAssetReward = (r) => ({
-  value: r.dailyAmount.toLocaleString(undefined, TOKEN_FORMAT),
+const transformAssetReward = (r: IPortfolioReward) => ({
+  value: r.newDailyAmount.toLocaleString(undefined, TOKEN_FORMAT),
   tooltip: `${r.unclaimedAmount.toLocaleString(undefined, TOKEN_FORMAT)} unclaimed`,
   text: r.symbol,
   icon: r.icon,

--- a/src/redux/selectors/getAccountRewards.ts
+++ b/src/redux/selectors/getAccountRewards.ts
@@ -10,7 +10,7 @@ import { getStaking } from "./getStaking";
 import { INetTvlFarmRewards } from "../../interfaces";
 import { toUsd } from "../utils";
 
-interface IPortfolioReward {
+export interface IPortfolioReward {
   icon: string;
   name: string;
   symbol: string;


### PR DESCRIPTION
### Summary
When updating our integration for Net Liquidity rewards found that our rewards per day weren't matching up.

My assumption is that the netTVL rewards per day should also be using the BRRR staking multiplier if a user is staking their BRRR. Found that this fixed the mismatch.

- use `newDailyAmount` for rewards per day in transformAssetReward