### PR TITLE
Fix / net liquidity

### DIFF
--- a/src/components/Header/stats/apy.tsx
+++ b/src/components/Header/stats/apy.tsx
@@ -18,7 +18,7 @@ export const APY = () => {
   return (
     <Stat
       title="APY"
-      titleTooltip="Your total APY"
+      titleTooltip="Net APY of all supply and borrow positions, including base APYs and incentives"
       amount={amount}
       tooltip={tooltip}
       labels={[apyLabels]}

--- a/src/components/Header/stats/apy.tsx
+++ b/src/components/Header/stats/apy.tsx
@@ -1,16 +1,27 @@
+import { Link, Stack, Typography } from "@mui/material";
+
 import { Stat } from "./components";
 import { useUserHealth } from "../../../hooks/useUserHealth";
 import { APY_FORMAT, USD_FORMAT } from "../../../store";
+import { useNonFarmedAssets } from "../../../hooks/hooks";
 
 export const APY = () => {
-  const { netAPY, netTvlAPY, dailyReturns } = useUserHealth();
+  const { netAPY, netLiquidityAPY, dailyReturns } = useUserHealth();
+  const { weightedNetLiquidity, hasNegativeNetLiquidity, assets } = useNonFarmedAssets();
+
   const globalValue = `${netAPY.toLocaleString(undefined, APY_FORMAT)}%`;
-  const netTvlValue = `${netTvlAPY.toLocaleString(undefined, APY_FORMAT)}%`;
-  const amount = `${(netAPY + netTvlAPY).toLocaleString(undefined, APY_FORMAT)}%`;
+  const netLiquidityValue = `${netLiquidityAPY.toLocaleString(undefined, APY_FORMAT)}%`;
+  const amount = `${(netAPY + netLiquidityAPY).toLocaleString(undefined, APY_FORMAT)}%`;
+
+  const netLiquidityTooltip = hasNegativeNetLiquidity ? (
+    <NotFarmingNetLiquidity assets={assets} liquidity={weightedNetLiquidity} />
+  ) : undefined;
 
   const apyLabels = [
-    { value: globalValue, text: "Pools" },
-    { value: netTvlValue, text: "Net Liquidity" },
+    [
+      { value: globalValue, text: "Pools" },
+      { value: netLiquidityValue, text: "Net Liquidity", tooltip: netLiquidityTooltip },
+    ],
   ];
 
   const tooltip = `${dailyReturns.toLocaleString(undefined, USD_FORMAT)} / day`;
@@ -21,7 +32,40 @@ export const APY = () => {
       titleTooltip="Net APY of all supply and borrow positions, including base APYs and incentives"
       amount={amount}
       tooltip={tooltip}
-      labels={[apyLabels]}
+      labels={apyLabels}
     />
   );
 };
+
+const NotFarmingNetLiquidity = ({ assets, liquidity }) => (
+  <Stack gap="1">
+    <Typography fontSize="0.85rem">
+      Your weighted net liquidity is <b>{liquidity.toLocaleString(undefined, USD_FORMAT)}</b> which
+      is below 0.
+    </Typography>
+    <Typography fontSize="0.85rem">
+      The following assets have the net liquidity coefficient below 1:
+      <Stack gap={1} component="span" direction="row" display="inline-flex" ml={1}>
+        {assets.map((asset) => (
+          <span key={asset.token_id}>
+            {asset.metadata.symbol} ({asset.config.net_tvl_multiplier / 10000})
+          </span>
+        ))}
+      </Stack>
+    </Typography>
+    <Typography fontSize="0.85rem">
+      In order to start farming the net liquidity rewards you need to have a positive balance.
+    </Typography>
+    <Typography fontSize="0.85rem">
+      For more information about the net liquidity coefficients{" "}
+      <Link
+        href="https://burrowcash.medium.com/net-liquidity-farming-part-2-varied-coefficients-6b839ae2178b"
+        target="_blank"
+        color="#ACFFD1"
+        fontWeight={500}
+      >
+        click here
+      </Link>
+    </Typography>
+  </Stack>
+);

--- a/src/components/Header/stats/apy.tsx
+++ b/src/components/Header/stats/apy.tsx
@@ -15,5 +15,13 @@ export const APY = () => {
 
   const tooltip = `${dailyReturns.toLocaleString(undefined, USD_FORMAT)} / day`;
 
-  return <Stat title="APY" amount={amount} tooltip={tooltip} labels={[apyLabels]} />;
+  return (
+    <Stat
+      title="APY"
+      titleTooltip="Your total APY"
+      amount={amount}
+      tooltip={tooltip}
+      labels={[apyLabels]}
+    />
+  );
 };

--- a/src/components/Header/stats/apy.tsx
+++ b/src/components/Header/stats/apy.tsx
@@ -19,8 +19,13 @@ export const APY = () => {
 
   const apyLabels = [
     [
-      { value: globalValue, text: "Pools" },
-      { value: netLiquidityValue, text: "Net Liquidity", tooltip: netLiquidityTooltip },
+      { value: globalValue, text: "Pools", color: netAPY < 0 ? "red" : "green" },
+      {
+        value: netLiquidityValue,
+        text: "Net Liquidity",
+        tooltip: netLiquidityTooltip,
+        color: hasNegativeNetLiquidity ? "yellow" : "green",
+      },
     ],
   ];
 

--- a/src/components/Header/stats/components.tsx
+++ b/src/components/Header/stats/components.tsx
@@ -59,7 +59,7 @@ export const Stat = ({
   labels,
   onClick,
 }: {
-  title: string;
+  title: string | React.ReactElement;
   amount: string;
   tooltip?: string;
   labels?: any;
@@ -83,9 +83,13 @@ export const Stat = ({
 
   return (
     <Stack onClick={() => onClick && onClick()} sx={{ cursor: onClick ? "pointer" : "inherit" }}>
-      <Typography color="#F8F9FF" fontSize="0.875rem">
-        {title}
-      </Typography>
+      {typeof title === "string" ? (
+        <Typography color="#F8F9FF" fontSize="0.875rem">
+          {title}
+        </Typography>
+      ) : (
+        title
+      )}
       <Tooltip title={tooltip} placement="top" arrow>
         <Typography
           sx={{

--- a/src/components/Header/stats/components.tsx
+++ b/src/components/Header/stats/components.tsx
@@ -53,6 +53,23 @@ export const StatsToggleButtons = () => {
   );
 };
 
+const COLORS = {
+  green: {
+    bgcolor: "rgba(172, 255, 255, 0.1)",
+    color: "#ACFFD1",
+  },
+  yellow: {
+    bgcolor: "rgba(255, 255, 172, 0.1)",
+    color: "#FFAC00",
+  },
+  red: {
+    bgcolor: "rgba(255, 172, 172, 0.1)",
+    color: "#FFACAC",
+  },
+};
+
+const getColor = (color = "green") => COLORS[color];
+
 export const Stat = ({
   title,
   titleTooltip = "",
@@ -69,13 +86,23 @@ export const Stat = ({
   onClick?: () => void;
 }) => {
   const renderLabel = (label, key) => (
-    <Label key={key} ml={label.icon ? "10px" : 0} tooltip={label.tooltip}>
+    <Label
+      key={key}
+      ml={label.icon ? "10px" : 0}
+      bgcolor={getColor(label.color).bgcolor}
+      tooltip={label.tooltip}
+    >
       {label.icon && (
         <Box position="absolute" top="0" left="-10px" borderRadius={19} border="0.5px solid white">
           <TokenIcon width={19} height={19} icon={label.icon} />
         </Box>
       )}
-      <Box component="span" color="#ACFFD1" fontWeight={600} pl={label.icon ? "10px" : 0}>
+      <Box
+        component="span"
+        color={getColor(label.color).color}
+        fontWeight={600}
+        pl={label.icon ? "10px" : 0}
+      >
         {label.value}
       </Box>
       <Box component="span" fontWeight={400}>
@@ -132,12 +159,12 @@ export const Stat = ({
   );
 };
 
-const Label = ({ children, tooltip = "", ...props }) => (
+const Label = ({ children, tooltip = "", bgcolor = "rgba(172, 255, 255, 0.1)", ...props }) => (
   <Tooltip title={tooltip} placement="top" arrow>
     <Stack
       direction="row"
       gap="4px"
-      bgcolor="rgba(172, 255, 255, 0.1)"
+      bgcolor={bgcolor}
       borderRadius="4px"
       py="4px"
       px="6px"

--- a/src/components/Header/stats/components.tsx
+++ b/src/components/Header/stats/components.tsx
@@ -98,7 +98,7 @@ export const Stat = ({
             )}
             {titleTooltip && (
               <MdInfoOutline
-                style={{ marginLeft: "3px", color: "#909090", position: "relative", top: "-2px" }}
+                style={{ marginLeft: "3px", color: "#909090", position: "relative", top: "-6px" }}
               />
             )}
           </Stack>

--- a/src/components/Header/stats/components.tsx
+++ b/src/components/Header/stats/components.tsx
@@ -1,5 +1,6 @@
 import { isValidElement } from "react";
 import { Box, Stack, ButtonGroup, Button, Typography, Tooltip } from "@mui/material";
+import { MdInfoOutline } from "@react-icons/all-files/md/MdInfoOutline";
 
 import { useAccountId } from "../../../hooks/hooks";
 import { useStatsToggle } from "../../../hooks/useStatsToggle";
@@ -54,12 +55,14 @@ export const StatsToggleButtons = () => {
 
 export const Stat = ({
   title,
+  titleTooltip = "",
   amount,
   tooltip = "",
   labels,
   onClick,
 }: {
   title: string | React.ReactElement;
+  titleTooltip?: string | React.ReactElement;
   amount: string;
   tooltip?: string;
   labels?: any;
@@ -84,13 +87,22 @@ export const Stat = ({
   return (
     <Stack onClick={() => onClick && onClick()} sx={{ cursor: onClick ? "pointer" : "inherit" }}>
       <Stack height={40} justifyContent="end">
-        {typeof title === "string" ? (
-          <Typography color="#F8F9FF" fontSize="0.875rem">
-            {title}
-          </Typography>
-        ) : (
-          title
-        )}
+        <Tooltip title={titleTooltip} placement="top" arrow>
+          <Stack direction="row" alignItems="end" width="max-content">
+            {typeof title === "string" ? (
+              <Typography color="#F8F9FF" fontSize="0.875rem">
+                {title}
+              </Typography>
+            ) : (
+              title
+            )}
+            {titleTooltip && (
+              <MdInfoOutline
+                style={{ marginLeft: "3px", color: "#909090", position: "relative", top: "-2px" }}
+              />
+            )}
+          </Stack>
+        </Tooltip>
       </Stack>
       <Tooltip title={tooltip} placement="top" arrow>
         <Typography

--- a/src/components/Header/stats/components.tsx
+++ b/src/components/Header/stats/components.tsx
@@ -83,13 +83,15 @@ export const Stat = ({
 
   return (
     <Stack onClick={() => onClick && onClick()} sx={{ cursor: onClick ? "pointer" : "inherit" }}>
-      {typeof title === "string" ? (
-        <Typography color="#F8F9FF" fontSize="0.875rem">
-          {title}
-        </Typography>
-      ) : (
-        title
-      )}
+      <Stack height={40} justifyContent="end">
+        {typeof title === "string" ? (
+          <Typography color="#F8F9FF" fontSize="0.875rem">
+            {title}
+          </Typography>
+        ) : (
+          title
+        )}
+      </Stack>
       <Tooltip title={tooltip} placement="top" arrow>
         <Typography
           sx={{

--- a/src/components/Header/stats/health.tsx
+++ b/src/components/Header/stats/health.tsx
@@ -33,5 +33,12 @@ export const HealthFactor = () => {
 
   const hfLabels = <Box color={color}>{label}</Box>;
 
-  return <Stat title="Health Factor" amount={amount} labels={hfLabels} />;
+  return (
+    <Stat
+      title="Health Factor"
+      titleTooltip="Your health factor (if it's below 100% you're up for liquidation)"
+      amount={amount}
+      labels={hfLabels}
+    />
+  );
 };

--- a/src/components/Header/stats/health.tsx
+++ b/src/components/Header/stats/health.tsx
@@ -36,7 +36,7 @@ export const HealthFactor = () => {
   return (
     <Stat
       title="Health Factor"
-      titleTooltip="Your health factor (if it's below 100% you're up for liquidation)"
+      titleTooltip="Represents the combined collateral ratios of the borrowed assets. If it is less than 100%, your account can be partially liquidated"
       amount={amount}
       labels={hfLabels}
     />

--- a/src/components/Header/stats/liquidity.tsx
+++ b/src/components/Header/stats/liquidity.tsx
@@ -8,7 +8,7 @@ import { getTotalAccountBalance } from "../../../redux/selectors/getTotalAccount
 import { m, COMPACT_USD_FORMAT } from "../../../store";
 import { trackFullDigits } from "../../../telemetry";
 import { Stat } from "./components";
-import { getAdjustedNetLiquidity } from "../../../redux/selectors/getAccountRewards";
+import { getWeightedNetLiquidity } from "../../../redux/selectors/getAccountRewards";
 
 export const ProtocolLiquidity = () => {
   const { fullDigits, setDigits } = useFullDigits();
@@ -29,14 +29,16 @@ export const ProtocolLiquidity = () => {
     : `$${m(protocolBorrowed)}`;
 
   const netLiquidityLabels = [
-    {
-      value: protocolDepositedValue,
-      text: "Deposited",
-    },
-    {
-      value: protocolBorrowedValue,
-      text: "Borrowed",
-    },
+    [
+      {
+        value: protocolDepositedValue,
+        text: "Deposited",
+      },
+      {
+        value: protocolBorrowedValue,
+        text: "Borrowed",
+      },
+    ],
   ];
 
   const toggleValues = () => {
@@ -49,7 +51,7 @@ export const ProtocolLiquidity = () => {
     <Stat
       title="Net Liquidity"
       amount={protocolNetLiquidityValue}
-      labels={[netLiquidityLabels]}
+      labels={netLiquidityLabels}
       onClick={toggleValues}
     />
   );
@@ -60,15 +62,15 @@ export const UserLiquidity = () => {
   const userDeposited = useAppSelector(getTotalAccountBalance("supplied"));
   const userBorrowed = useAppSelector(getTotalAccountBalance("borrowed"));
   const userNetLiquidity = userDeposited - userBorrowed;
-  const adjustedNetLiquidity = useAppSelector(getAdjustedNetLiquidity);
+  const weightedNetLiquidity = useAppSelector(getWeightedNetLiquidity);
 
   const userNetLiquidityValue = fullDigits?.user
     ? userNetLiquidity.toLocaleString(undefined, COMPACT_USD_FORMAT)
     : `$${m(userNetLiquidity)}`;
 
-  const userAdjustedNetLiquidityValue = fullDigits?.user
-    ? adjustedNetLiquidity.toLocaleString(undefined, COMPACT_USD_FORMAT)
-    : `$${m(adjustedNetLiquidity)}`;
+  const userWeightedNetLiquidityValue = fullDigits?.user
+    ? weightedNetLiquidity.toLocaleString(undefined, COMPACT_USD_FORMAT)
+    : `$${m(weightedNetLiquidity)}`;
 
   const userDepositedValue = fullDigits?.user
     ? userDeposited.toLocaleString(undefined, COMPACT_USD_FORMAT)
@@ -100,7 +102,7 @@ export const UserLiquidity = () => {
   const title = (
     <Tooltip title={`Your full net liquidity is: ${userNetLiquidityValue}`} placement="top" arrow>
       <Box component="span">
-        <span>Net Liquidity</span>
+        <span>Weighted Net Liquidity</span>
         <MdInfoOutline
           style={{ marginLeft: "3px", color: "#909090", position: "relative", top: "2px" }}
         />
@@ -111,7 +113,7 @@ export const UserLiquidity = () => {
   return (
     <Stat
       title={title}
-      amount={userAdjustedNetLiquidityValue}
+      amount={userWeightedNetLiquidityValue}
       labels={netLiquidityLabels}
       onClick={toggleValues}
     />

--- a/src/components/Header/stats/liquidity.tsx
+++ b/src/components/Header/stats/liquidity.tsx
@@ -101,8 +101,9 @@ export const UserLiquidity = () => {
 
   const title = (
     <Tooltip title={`Your full net liquidity is: ${userNetLiquidityValue}`} placement="top" arrow>
-      <Box component="span">
-        <span>Weighted Net Liquidity</span>
+      <Box component="span" maxWidth={120}>
+        <Box>Weighted</Box>
+        <span>Net Liquidity</span>
         <MdInfoOutline
           style={{ marginLeft: "3px", color: "#909090", position: "relative", top: "2px" }}
         />

--- a/src/components/Header/stats/liquidity.tsx
+++ b/src/components/Header/stats/liquidity.tsx
@@ -11,11 +11,7 @@ import { useProtocolNetLiquidity } from "../../../hooks/useNetLiquidity";
 
 export const ProtocolLiquidity = () => {
   const { fullDigits, setDigits } = useFullDigits();
-  const { protocolBorrowed, protocolDeposited, protocolNetLiquidity } = useProtocolNetLiquidity();
-
-  const protocolNetLiquidityValue = fullDigits?.totals
-    ? protocolNetLiquidity.toLocaleString(undefined, COMPACT_USD_FORMAT)
-    : `$${m(protocolNetLiquidity)}`;
+  const { protocolBorrowed, protocolDeposited } = useProtocolNetLiquidity();
 
   const protocolDepositedValue = fullDigits?.totals
     ? protocolDeposited.toLocaleString(undefined, COMPACT_USD_FORMAT)
@@ -25,19 +21,6 @@ export const ProtocolLiquidity = () => {
     ? protocolBorrowed.toLocaleString(undefined, COMPACT_USD_FORMAT)
     : `$${m(protocolBorrowed)}`;
 
-  const netLiquidityLabels = [
-    [
-      {
-        value: protocolDepositedValue,
-        text: "Deposited",
-      },
-      {
-        value: protocolBorrowedValue,
-        text: "Borrowed",
-      },
-    ],
-  ];
-
   const toggleValues = () => {
     const totals = !fullDigits?.totals;
     trackFullDigits({ totals });
@@ -45,13 +28,20 @@ export const ProtocolLiquidity = () => {
   };
 
   return (
-    <Stat
-      title="Net Liquidity"
-      titleTooltip="Protocol liquid balance"
-      amount={protocolNetLiquidityValue}
-      labels={netLiquidityLabels}
-      onClick={toggleValues}
-    />
+    <>
+      <Stat
+        title="Deposited"
+        titleTooltip="Total deposits"
+        amount={protocolDepositedValue}
+        onClick={toggleValues}
+      />
+      <Stat
+        title="Borrowed"
+        titleTooltip="Total borrows"
+        amount={protocolBorrowedValue}
+        onClick={toggleValues}
+      />
+    </>
   );
 };
 

--- a/src/components/Header/stats/liquidity.tsx
+++ b/src/components/Header/stats/liquidity.tsx
@@ -2,18 +2,16 @@ import { Box } from "@mui/material";
 
 import { useFullDigits } from "../../../hooks/useFullDigits";
 import { useAppSelector } from "../../../redux/hooks";
-import { getTotalBalance } from "../../../redux/selectors/getTotalBalance";
 import { getTotalAccountBalance } from "../../../redux/selectors/getTotalAccountBalance";
 import { m, COMPACT_USD_FORMAT } from "../../../store";
 import { trackFullDigits } from "../../../telemetry";
 import { Stat } from "./components";
 import { getWeightedNetLiquidity } from "../../../redux/selectors/getAccountRewards";
+import { useProtocolNetLiquidity } from "../../../hooks/useNetLiquidity";
 
 export const ProtocolLiquidity = () => {
   const { fullDigits, setDigits } = useFullDigits();
-  const protocolDeposited = useAppSelector(getTotalBalance("supplied"));
-  const protocolBorrowed = useAppSelector(getTotalBalance("borrowed"));
-  const protocolNetLiquidity = protocolDeposited - protocolBorrowed;
+  const { protocolBorrowed, protocolDeposited, protocolNetLiquidity } = useProtocolNetLiquidity();
 
   const protocolNetLiquidityValue = fullDigits?.totals
     ? protocolNetLiquidity.toLocaleString(undefined, COMPACT_USD_FORMAT)

--- a/src/components/Header/stats/liquidity.tsx
+++ b/src/components/Header/stats/liquidity.tsx
@@ -1,3 +1,6 @@
+import { Tooltip, Box } from "@mui/material";
+import { MdInfoOutline } from "@react-icons/all-files/md/MdInfoOutline";
+
 import { useFullDigits } from "../../../hooks/useFullDigits";
 import { useAppSelector } from "../../../redux/hooks";
 import { getTotalBalance } from "../../../redux/selectors/getTotalBalance";
@@ -5,6 +8,7 @@ import { getTotalAccountBalance } from "../../../redux/selectors/getTotalAccount
 import { m, COMPACT_USD_FORMAT } from "../../../store";
 import { trackFullDigits } from "../../../telemetry";
 import { Stat } from "./components";
+import { getAdjustedNetLiquidity } from "../../../redux/selectors/getAccountRewards";
 
 export const ProtocolLiquidity = () => {
   const { fullDigits, setDigits } = useFullDigits();
@@ -56,10 +60,15 @@ export const UserLiquidity = () => {
   const userDeposited = useAppSelector(getTotalAccountBalance("supplied"));
   const userBorrowed = useAppSelector(getTotalAccountBalance("borrowed"));
   const userNetLiquidity = userDeposited - userBorrowed;
+  const adjustedNetLiquidity = useAppSelector(getAdjustedNetLiquidity);
 
   const userNetLiquidityValue = fullDigits?.user
     ? userNetLiquidity.toLocaleString(undefined, COMPACT_USD_FORMAT)
     : `$${m(userNetLiquidity)}`;
+
+  const userAdjustedNetLiquidityValue = fullDigits?.user
+    ? adjustedNetLiquidity.toLocaleString(undefined, COMPACT_USD_FORMAT)
+    : `$${m(adjustedNetLiquidity)}`;
 
   const userDepositedValue = fullDigits?.user
     ? userDeposited.toLocaleString(undefined, COMPACT_USD_FORMAT)
@@ -70,14 +79,16 @@ export const UserLiquidity = () => {
     : `$${m(userBorrowed)}`;
 
   const netLiquidityLabels = [
-    {
-      value: userDepositedValue,
-      text: "Deposited",
-    },
-    {
-      value: userBorrowedValue,
-      text: "Borrowed",
-    },
+    [
+      {
+        value: userDepositedValue,
+        text: "Deposited",
+      },
+      {
+        value: userBorrowedValue,
+        text: "Borrowed",
+      },
+    ],
   ];
 
   const toggleValues = () => {
@@ -86,11 +97,22 @@ export const UserLiquidity = () => {
     setDigits({ user });
   };
 
+  const title = (
+    <Tooltip title={`Your full net liquidity is: ${userNetLiquidityValue}`} placement="top" arrow>
+      <Box component="span">
+        <span>Net Liquidity</span>
+        <MdInfoOutline
+          style={{ marginLeft: "3px", color: "#909090", position: "relative", top: "2px" }}
+        />
+      </Box>
+    </Tooltip>
+  );
+
   return (
     <Stat
-      title="Net Liquidity"
-      amount={userNetLiquidityValue}
-      labels={[netLiquidityLabels]}
+      title={title}
+      amount={userAdjustedNetLiquidityValue}
+      labels={netLiquidityLabels}
       onClick={toggleValues}
     />
   );

--- a/src/components/Header/stats/liquidity.tsx
+++ b/src/components/Header/stats/liquidity.tsx
@@ -1,5 +1,4 @@
-import { Tooltip, Box } from "@mui/material";
-import { MdInfoOutline } from "@react-icons/all-files/md/MdInfoOutline";
+import { Box } from "@mui/material";
 
 import { useFullDigits } from "../../../hooks/useFullDigits";
 import { useAppSelector } from "../../../redux/hooks";
@@ -50,6 +49,7 @@ export const ProtocolLiquidity = () => {
   return (
     <Stat
       title="Net Liquidity"
+      titleTooltip="Protocol liquid balance"
       amount={protocolNetLiquidityValue}
       labels={netLiquidityLabels}
       onClick={toggleValues}
@@ -100,20 +100,16 @@ export const UserLiquidity = () => {
   };
 
   const title = (
-    <Tooltip title={`Your full net liquidity is: ${userNetLiquidityValue}`} placement="top" arrow>
-      <Box component="span" maxWidth={120}>
-        <Box>Weighted</Box>
-        <span>Net Liquidity</span>
-        <MdInfoOutline
-          style={{ marginLeft: "3px", color: "#909090", position: "relative", top: "2px" }}
-        />
-      </Box>
-    </Tooltip>
+    <Box component="span" maxWidth={120}>
+      <Box>Weighted</Box>
+      <span>Net Liquidity</span>
+    </Box>
   );
 
   return (
     <Stat
       title={title}
+      titleTooltip={`Your full net liquidity is: ${userNetLiquidityValue}`}
       amount={userWeightedNetLiquidityValue}
       labels={netLiquidityLabels}
       onClick={toggleValues}

--- a/src/components/Header/stats/liquidity.tsx
+++ b/src/components/Header/stats/liquidity.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@mui/material";
+import { Typography } from "@mui/material";
 
 import { useFullDigits } from "../../../hooks/useFullDigits";
 import { useAppSelector } from "../../../redux/hooks";
@@ -97,17 +97,12 @@ export const UserLiquidity = () => {
     setDigits({ user });
   };
 
-  const title = (
-    <Box component="span" maxWidth={120}>
-      <Box>Weighted</Box>
-      <span>Net Liquidity</span>
-    </Box>
-  );
+  const title = <Typography>Weighted Net Liquidity</Typography>;
 
   return (
     <Stat
       title={title}
-      titleTooltip={`Your full net liquidity is: ${userNetLiquidityValue}`}
+      titleTooltip={`Your unweighted net liquidity is: ${userNetLiquidityValue}`}
       amount={userWeightedNetLiquidityValue}
       labels={netLiquidityLabels}
       onClick={toggleValues}

--- a/src/components/Header/stats/rewards.tsx
+++ b/src/components/Header/stats/rewards.tsx
@@ -33,7 +33,7 @@ export const UserDailyRewards = () => {
   return (
     <Stat
       title="Daily Rewards"
-      titleTooltip="Estimated daily rewards combing base APYs and all incentives"
+      titleTooltip="Estimated daily reward from incentives"
       amount={amount.toLocaleString(undefined, USD_FORMAT)}
       labels={labels}
     />

--- a/src/components/Header/stats/rewards.tsx
+++ b/src/components/Header/stats/rewards.tsx
@@ -43,7 +43,7 @@ export const UserDailyRewards = () => {
   return (
     <Stat
       title="Daily Rewards"
-      titleTooltip="Your total daily rewards from asset pools and net liquidity"
+      titleTooltip="Estimated daily rewards combing base APYs and all incentives"
       amount={amount.toLocaleString(undefined, USD_FORMAT)}
       labels={labels}
     />

--- a/src/components/Header/stats/rewards.tsx
+++ b/src/components/Header/stats/rewards.tsx
@@ -26,7 +26,7 @@ export const UserDailyRewards = () => {
 
   const labels = [
     [{ text: "Pools:" }, ...assetLabels],
-    [{ text: "Net Liquidity:" }, ...netLabels],
+    netLabels.length ? [{ text: "Net Liquidity:" }, ...netLabels] : [],
   ];
   const amount = assetRewards.reduce(sumRewards, 0) + netRewards.reduce(sumRewards, 0);
 

--- a/src/components/Header/stats/rewards.tsx
+++ b/src/components/Header/stats/rewards.tsx
@@ -15,7 +15,7 @@ const sumRewards = (acc, r) => acc + r.dailyAmount * r.price;
 
 export const UserDailyRewards = () => {
   const { brrr, extra, net } = useRewards();
-  const { adjustedNetLiquidity, hasNegativeNetLiquidity, assets } = useNonFarmedAssets();
+  const { weightedNetLiquidity, hasNegativeNetLiquidity, assets } = useNonFarmedAssets();
 
   const assetRewards = [
     ...(Object.entries(brrr).length > 0 ? [brrr] : []),
@@ -29,7 +29,7 @@ export const UserDailyRewards = () => {
     ? [
         {
           value: "not farming...",
-          tooltip: <NotFarmingNetLiquidity assets={assets} liquidity={adjustedNetLiquidity} />,
+          tooltip: <NotFarmingNetLiquidity assets={assets} liquidity={weightedNetLiquidity} />,
         },
       ]
     : netRewards.map(transformAssetReward);
@@ -52,7 +52,7 @@ export const UserDailyRewards = () => {
 const NotFarmingNetLiquidity = ({ assets, liquidity }) => (
   <Stack gap="1">
     <Typography fontSize="0.85rem">
-      Your adjusted net liquidity is <b>{liquidity.toLocaleString(undefined, USD_FORMAT)}</b> which
+      Your weighted net liquidity is <b>{liquidity.toLocaleString(undefined, USD_FORMAT)}</b> which
       is below 0.
     </Typography>
     <Typography fontSize="0.85rem">

--- a/src/components/Header/stats/rewards.tsx
+++ b/src/components/Header/stats/rewards.tsx
@@ -43,6 +43,7 @@ export const UserDailyRewards = () => {
   return (
     <Stat
       title="Daily Rewards"
+      titleTooltip="Your total daily rewards from asset pools and net liquidity"
       amount={amount.toLocaleString(undefined, USD_FORMAT)}
       labels={labels}
     />
@@ -98,6 +99,7 @@ export const ProtocolDailyRewards = () => {
   return (
     <Stat
       title="Net Liquidity Daily Rewards"
+      titleTooltip="Total protocol daily rewards from net liquidity"
       amount={amount.toLocaleString(undefined, USD_FORMAT)}
       labels={[labels]}
     />

--- a/src/components/Header/stats/rewards.tsx
+++ b/src/components/Header/stats/rewards.tsx
@@ -1,5 +1,3 @@
-import { Link, Stack, Typography } from "@mui/material";
-import { useNonFarmedAssets } from "../../../hooks/hooks";
 import { useRewards } from "../../../hooks/useRewards";
 import { TOKEN_FORMAT, USD_FORMAT, NUMBER_FORMAT } from "../../../store";
 import { Stat } from "./components";
@@ -15,7 +13,6 @@ const sumRewards = (acc, r) => acc + r.dailyAmount * r.price;
 
 export const UserDailyRewards = () => {
   const { brrr, extra, net } = useRewards();
-  const { weightedNetLiquidity, hasNegativeNetLiquidity, assets } = useNonFarmedAssets();
 
   const assetRewards = [
     ...(Object.entries(brrr).length > 0 ? [brrr] : []),
@@ -25,14 +22,7 @@ export const UserDailyRewards = () => {
   const netRewards = net.flatMap((f) => f[1]);
 
   const assetLabels = assetRewards.map(transformAssetReward);
-  const netLabels = hasNegativeNetLiquidity
-    ? [
-        {
-          value: "not farming...",
-          tooltip: <NotFarmingNetLiquidity assets={assets} liquidity={weightedNetLiquidity} />,
-        },
-      ]
-    : netRewards.map(transformAssetReward);
+  const netLabels = netRewards.map(transformAssetReward);
 
   const labels = [
     [{ text: "Pools:" }, ...assetLabels],
@@ -49,39 +39,6 @@ export const UserDailyRewards = () => {
     />
   );
 };
-
-const NotFarmingNetLiquidity = ({ assets, liquidity }) => (
-  <Stack gap="1">
-    <Typography fontSize="0.85rem">
-      Your weighted net liquidity is <b>{liquidity.toLocaleString(undefined, USD_FORMAT)}</b> which
-      is below 0.
-    </Typography>
-    <Typography fontSize="0.85rem">
-      The following assets have the net liquidity coefficient below 1:
-      <Stack gap={1} component="span" direction="row" display="inline-flex" ml={1}>
-        {assets.map((asset) => (
-          <span key={asset.token_id}>
-            {asset.metadata.symbol} ({asset.config.net_tvl_multiplier / 10000})
-          </span>
-        ))}
-      </Stack>
-    </Typography>
-    <Typography fontSize="0.85rem">
-      In order to start farming the net liquidity rewards you need to have a positive balance.
-    </Typography>
-    <Typography fontSize="0.85rem">
-      For more information about the net liquidity coefficients{" "}
-      <Link
-        href="https://burrowcash.medium.com/net-liquidity-farming-part-2-varied-coefficients-6b839ae2178b"
-        target="_blank"
-        color="#ACFFD1"
-        fontWeight={500}
-      >
-        click here
-      </Link>
-    </Typography>
-  </Stack>
-);
 
 const transformProtocolReward = (r) => ({
   value: r.dailyAmount.toLocaleString(undefined, NUMBER_FORMAT),

--- a/src/components/Header/stats/stats.tsx
+++ b/src/components/Header/stats/stats.tsx
@@ -40,6 +40,7 @@ export const StatsContainer = () => {
           "&::-webkit-scrollbar, & *::-webkit-scrollbar": {
             display: "none",
           },
+          scrollbarWidth: "none",
         }}
       >
         {protocolStats ? <ProtocolStats /> : accountId ? <UserStats /> : <ProtocolStats />}

--- a/src/components/OnboardingBRRR/index.tsx
+++ b/src/components/OnboardingBRRR/index.tsx
@@ -27,8 +27,7 @@ export default function OnboardingBRRR() {
           </span>{" "}
           by supplying and borrowing assets on Burrow.
           <Box textAlign="left" pt="0.75rem">
-            Up to 6% of the total supply will be distributed to early users and supporters within
-            the first 3 months!
+            Up to 50% of the total supply will be distributed to users and supporters!
           </Box>
         </Box>
       </Stack>
@@ -37,7 +36,7 @@ export default function OnboardingBRRR() {
         color="secondary"
         variant="outlined"
         target="_blank"
-        href="https://burrowcash.medium.com/burrow-is-live-on-mainnet-read-this-faq-to-get-started-add1572075a4"
+        href="https://burrowcash.medium.com/a-high-level-overview-of-brrr-tokenomics-b9b12abec3b6"
       >
         <Box whiteSpace="nowrap" px="1rem">
           LEARN MORE

--- a/src/components/Rewards/index.tsx
+++ b/src/components/Rewards/index.tsx
@@ -8,16 +8,17 @@ import { shrinkToken } from "../../store/helper";
 import { useFullDigits } from "../../hooks/useFullDigits";
 import TokenIcon from "../TokenIcon";
 import HtmlTooltip from "../common/html-tooltip";
-import { useNetLiquidityRewards } from "../../hooks/useRewards";
+import { useNetLiquidityRewards, useProRataNetLiquidityReward } from "../../hooks/useRewards";
 
 interface Props {
   rewards?: IReward[];
   layout?: "horizontal" | "vertical";
   fontWeight?: "normal" | "bold";
   page?: "deposit" | "borrow";
+  tokenId: string;
 }
 
-const Rewards = ({ rewards: list = [], layout, fontWeight = "normal", page }: Props) => {
+const Rewards = ({ rewards: list = [], layout, fontWeight = "normal", page, tokenId }: Props) => {
   const { fullDigits } = useFullDigits();
   const isCompact = fullDigits?.table;
   const isHorizontalLayout = layout === "horizontal";
@@ -32,6 +33,7 @@ const Rewards = ({ rewards: list = [], layout, fontWeight = "normal", page }: Pr
       hidden={!isHorizontalLayout}
       poolRewards={list}
       netLiquidityRewards={netLiquidityRewards}
+      tokenId={tokenId}
     >
       <Stack
         spacing={0.75}
@@ -91,7 +93,7 @@ const Rewards = ({ rewards: list = [], layout, fontWeight = "normal", page }: Pr
   );
 };
 
-const RewardsTooltip = ({ children, hidden, poolRewards, netLiquidityRewards }) => {
+const RewardsTooltip = ({ children, hidden, poolRewards, netLiquidityRewards, tokenId }) => {
   if (hidden) return children;
   const hasPoolRewards = poolRewards.length > 0;
   const hasNetLiquidityRewards = netLiquidityRewards.length > 0;
@@ -118,7 +120,7 @@ const RewardsTooltip = ({ children, hidden, poolRewards, netLiquidityRewards }) 
               </Typography>
               <Box display="grid" gridTemplateColumns="1fr 1fr" alignItems="center" gap={1}>
                 {netLiquidityRewards.map((r) => (
-                  <Reward key={r.metadata.symbol} {...r} />
+                  <Reward key={r.metadata.symbol} {...r} tokenId={tokenId} />
                 ))}
               </Box>
             </>
@@ -131,15 +133,16 @@ const RewardsTooltip = ({ children, hidden, poolRewards, netLiquidityRewards }) 
   );
 };
 
-const Reward = ({ metadata, rewards, config }) => {
+const Reward = ({ metadata, rewards, config, tokenId }) => {
   const { fullDigits } = useFullDigits();
   const isCompact = fullDigits?.table;
-
   const { symbol, icon, decimals } = metadata;
   const dailyRewards = shrinkToken(rewards.reward_per_day || 0, decimals + config.extra_decimals);
+  const rewardAmount = useProRataNetLiquidityReward(tokenId, dailyRewards);
+
   const amount = isCompact
-    ? millify(Number(dailyRewards), { precision: PERCENT_DIGITS })
-    : formatRewardAmount(Number(dailyRewards));
+    ? millify(Number(rewardAmount), { precision: PERCENT_DIGITS })
+    : formatRewardAmount(Number(rewardAmount));
 
   return (
     <>

--- a/src/components/Rewards/index.tsx
+++ b/src/components/Rewards/index.tsx
@@ -14,13 +14,14 @@ interface Props {
   rewards?: IReward[];
   layout?: "horizontal" | "vertical";
   fontWeight?: "normal" | "bold";
+  page?: "deposit" | "borrow";
 }
 
-const Rewards = ({ rewards: list = [], layout, fontWeight = "normal" }: Props) => {
+const Rewards = ({ rewards: list = [], layout, fontWeight = "normal", page }: Props) => {
   const { fullDigits } = useFullDigits();
   const isCompact = fullDigits?.table;
   const isHorizontalLayout = layout === "horizontal";
-  const netLiquidityRewards = useNetLiquidityRewards();
+  const netLiquidityRewards = page === "deposit" ? useNetLiquidityRewards() : [];
 
   const restRewards = netLiquidityRewards.filter(
     (r) => !list.some((lr) => lr.metadata.symbol === r.metadata.symbol),

--- a/src/components/Table/common/apy-cell.tsx
+++ b/src/components/Table/common/apy-cell.tsx
@@ -46,7 +46,7 @@ const APYCell = ({
 
   const sign = isBorrow ? -1 : 1;
   const apy = isStaking ? stakingExtraAPY : extraAPY;
-  const boostedAPY = baseAPY + netLiquidityAPY * netTvlMultiplier + sign * apy;
+  const boostedAPY = baseAPY + (isBorrow ? 0 : netLiquidityAPY) * netTvlMultiplier + sign * apy;
   const isLucky = isBorrow && boostedAPY <= 0;
 
   return (
@@ -106,12 +106,14 @@ const ToolTip = ({
           <Typography fontSize="0.75rem" textAlign="right">
             {toAPY(baseAPY)}%
           </Typography>
-          <Typography pl="22px" fontSize="0.75rem">
-            Net Liquidity APY
-          </Typography>
-          <Typography fontSize="0.75rem" textAlign="right">
-            {toAPY(netLiquidityAPY * netTvlMultiplier)}%
-          </Typography>
+          {!isBorrow && [
+            <Typography pl="22px" fontSize="0.75rem" key={0}>
+              Net Liquidity APY
+            </Typography>,
+            <Typography fontSize="0.75rem" textAlign="right" key={1}>
+              {toAPY(netLiquidityAPY * netTvlMultiplier)}%
+            </Typography>,
+          ]}
           {list.map(({ rewards, metadata, price, config }) => {
             const { symbol, icon } = metadata;
 

--- a/src/components/Table/common/cells.tsx
+++ b/src/components/Table/common/cells.tsx
@@ -58,7 +58,7 @@ export const Cell = ({
 
   if (isAPY)
     return <APYCell rewards={rewards} baseAPY={value} page={page} tokenId={rowData.tokenId} />;
-  if (isReward) return <Rewards rewards={rewards} layout={rewardLayout} />;
+  if (isReward) return <Rewards rewards={rewards} layout={rewardLayout} page={page} />;
   if (!value) return <Box>-</Box>;
 
   const displayValue = formatMap[format](value);

--- a/src/components/Table/common/cells.tsx
+++ b/src/components/Table/common/cells.tsx
@@ -58,7 +58,10 @@ export const Cell = ({
 
   if (isAPY)
     return <APYCell rewards={rewards} baseAPY={value} page={page} tokenId={rowData.tokenId} />;
-  if (isReward) return <Rewards rewards={rewards} layout={rewardLayout} page={page} />;
+  if (isReward)
+    return (
+      <Rewards rewards={rewards} layout={rewardLayout} page={page} tokenId={rowData.tokenId} />
+    );
   if (!value) return <Box>-</Box>;
 
   const displayValue = formatMap[format](value);

--- a/src/hooks/hooks.ts
+++ b/src/hooks/hooks.ts
@@ -5,7 +5,7 @@ import { getPortfolioAssets } from "../redux/selectors/getPortfolioAssets";
 import { getConfig, getSlimStats, getDegenMode } from "../redux/appSelectors";
 import { setRepayFrom, toggleDegenMode } from "../redux/appSlice";
 import { getViewAs } from "../utils";
-import { getAdjustedAssets, getAdjustedNetLiquidity } from "../redux/selectors/getAccountRewards";
+import { getWeightedAssets, getWeightedNetLiquidity } from "../redux/selectors/getAccountRewards";
 
 export function useLoading() {
   const isLoadingAssets = useAppSelector(isAssetsLoading);
@@ -36,12 +36,12 @@ export function useAccountId() {
 }
 
 export function useNonFarmedAssets() {
-  const adjustedNetLiquidity = useAppSelector(getAdjustedNetLiquidity);
+  const weightedNetLiquidity = useAppSelector(getWeightedNetLiquidity);
   const hasNonFarmedAssets = useAppSelector(getHasNonFarmedAssets);
-  const hasNegativeNetLiquidity = adjustedNetLiquidity < 0;
-  const assets = useAppSelector(getAdjustedAssets);
+  const hasNegativeNetLiquidity = weightedNetLiquidity < 0;
+  const assets = useAppSelector(getWeightedAssets);
 
-  return { hasNonFarmedAssets, adjustedNetLiquidity, hasNegativeNetLiquidity, assets };
+  return { hasNonFarmedAssets, weightedNetLiquidity, hasNegativeNetLiquidity, assets };
 }
 
 export function useAvailableAssets(type: "supply" | "borrow") {

--- a/src/hooks/useExtraAPY.ts
+++ b/src/hooks/useExtraAPY.ts
@@ -8,6 +8,7 @@ import { getConfig } from "../redux/appSelectors";
 import { useAppSelector } from "../redux/hooks";
 import { shrinkToken } from "../store/helper";
 import { getNetTvlAPY, getTotalNetTvlAPY } from "../redux/selectors/getNetAPY";
+import { useNonFarmedAssets } from "./hooks";
 
 export function useExtraAPY({ tokenId: assetId, isBorrow }) {
   const [totalSupplyUSD, totalBorrowUSD] = useAppSelector(getTotalSupplyAndBorrowUSD(assetId));
@@ -17,9 +18,15 @@ export function useExtraAPY({ tokenId: assetId, isBorrow }) {
   const assets = useAppSelector(getAssets);
   const userNetTvlAPY = useAppSelector(getNetTvlAPY({ isStaking: false }));
   const totalNetTvlApy = useAppSelector(getTotalNetTvlAPY);
+  const { hasNegativeNetLiquidity } = useNonFarmedAssets();
 
   const hasNetTvlFarms = Object.keys(portfolio.farms.netTvl).length > 0;
-  const netLiquidityAPY = hasNetTvlFarms ? userNetTvlAPY : totalNetTvlApy;
+
+  const netLiquidityAPY = hasNegativeNetLiquidity
+    ? 0
+    : hasNetTvlFarms
+    ? userNetTvlAPY
+    : totalNetTvlApy;
 
   const asset = assets.data[assetId];
 

--- a/src/hooks/useNetLiquidity.ts
+++ b/src/hooks/useNetLiquidity.ts
@@ -1,0 +1,10 @@
+import { useAppSelector } from "../redux/hooks";
+
+import { getTotalBalance } from "../redux/selectors/getTotalBalance";
+
+export function useProtocolNetLiquidity() {
+  const protocolDeposited = useAppSelector(getTotalBalance("supplied"));
+  const protocolBorrowed = useAppSelector(getTotalBalance("borrowed"));
+  const protocolNetLiquidity = protocolDeposited - protocolBorrowed;
+  return { protocolDeposited, protocolBorrowed, protocolNetLiquidity };
+}

--- a/src/hooks/useRewards.ts
+++ b/src/hooks/useRewards.ts
@@ -1,6 +1,8 @@
 import { useAppSelector } from "../redux/hooks";
 import { getAccountRewards } from "../redux/selectors/getAccountRewards";
 import { getNetLiquidityRewards, getProtocolRewards } from "../redux/selectors/getProtocolRewards";
+import { getTokenLiquidity } from "../redux/selectors/getTokenLiquidity";
+import { useProtocolNetLiquidity } from "./useNetLiquidity";
 
 export function useRewards() {
   const assetRewards = useAppSelector(getAccountRewards);
@@ -16,4 +18,13 @@ export function useRewards() {
 export function useNetLiquidityRewards() {
   const rewards = useAppSelector(getNetLiquidityRewards);
   return rewards;
+}
+
+export function useProRataNetLiquidityReward(tokenId, dailyAmount) {
+  const { protocolNetLiquidity } = useProtocolNetLiquidity();
+  const tokenLiquidity = useAppSelector(getTokenLiquidity(tokenId));
+
+  if (!tokenId) return dailyAmount;
+  const share = tokenLiquidity / protocolNetLiquidity;
+  return dailyAmount * share;
 }

--- a/src/hooks/useUserHealth.ts
+++ b/src/hooks/useUserHealth.ts
@@ -12,7 +12,7 @@ export function useUserHealth() {
   const dispatch = useAppDispatch();
   const { showDailyReturns } = useAppSelector(getAppState);
   const netAPY = useAppSelector(getNetAPY({ isStaking: false }));
-  const netTvlAPY = useAppSelector(getNetTvlAPY({ isStaking: false }));
+  const netLiquidityAPY = useAppSelector(getNetTvlAPY({ isStaking: false }));
   const dailyReturns = useAppSelector(getDailyReturns);
   const healthFactor = useAppSelector(getHealthFactor);
   const { fullDigits, setDigits } = useFullDigits();
@@ -29,7 +29,7 @@ export function useUserHealth() {
 
   return {
     netAPY,
-    netTvlAPY,
+    netLiquidityAPY,
     dailyReturns,
     healthFactor,
     slimStats,

--- a/src/redux/selectors/getAccountRewards.ts
+++ b/src/redux/selectors/getAccountRewards.ts
@@ -254,7 +254,7 @@ export const getAccountRewards = createSelector(
   },
 );
 
-export const getAdjustedNetLiquidity = createSelector(
+export const getWeightedNetLiquidity = createSelector(
   (state: RootState) => state.assets,
   (state: RootState) => state.account,
   (assets, account) => {
@@ -269,7 +269,7 @@ export const getAdjustedNetLiquidity = createSelector(
   },
 );
 
-export const getAdjustedAssets = createSelector(
+export const getWeightedAssets = createSelector(
   (state: RootState) => state.assets,
   (assets) => {
     if (!hasAssets(assets)) return [];

--- a/src/redux/selectors/getNetAPY.ts
+++ b/src/redux/selectors/getNetAPY.ts
@@ -37,8 +37,8 @@ export const getNetTvlAPY = ({ isStaking = false }) =>
     (assets, account, rewards) => {
       if (!hasAssets(assets)) return 0;
 
-      const [, totalCollateral] = getGains(account.portfolio, assets, "collateral", true);
-      const [, totalSupplied] = getGains(account.portfolio, assets, "supplied", true);
+      const [, totalCollateral] = getGains(account.portfolio, assets, "collateral");
+      const [, totalSupplied] = getGains(account.portfolio, assets, "supplied");
 
       const netTvlRewards = Object.values(rewards.net).reduce(
         (acc, r) => acc + (isStaking ? r.newDailyAmount : r.dailyAmount) * r.price,

--- a/src/redux/selectors/getTokenLiquidity.ts
+++ b/src/redux/selectors/getTokenLiquidity.ts
@@ -1,0 +1,17 @@
+import { createSelector } from "@reduxjs/toolkit";
+
+import { RootState } from "../store";
+import { toUsd, hasAssets } from "../utils";
+
+export const getTokenLiquidity = (tokenId: string) =>
+  createSelector(
+    (state: RootState) => state.assets,
+    (assets) => {
+      if (!hasAssets(assets) || !tokenId) return 0;
+      const asset = assets.data[tokenId];
+      const supplied = toUsd(asset.supplied.balance, asset);
+      const reserved = toUsd(asset.reserved, asset);
+      const borrowed = toUsd(asset.borrowed.balance, asset);
+      return supplied + reserved - borrowed;
+    },
+  );

--- a/src/redux/selectors/getWithdrawMaxAmount.ts
+++ b/src/redux/selectors/getWithdrawMaxAmount.ts
@@ -49,7 +49,7 @@ export const computeWithdrawMaxAmount = (tokenId: string, assets: Assets, portfo
     const adjustedBorrowedSum = getAdjustedSum("borrowed", portfolio, assets);
 
     const adjustedPricedDiff = decimalMax(0, adjustedCollateralSum.sub(adjustedBorrowedSum));
-    const safeAdjustedPricedDiff = adjustedPricedDiff.mul(99).div(100);
+    const safeAdjustedPricedDiff = adjustedPricedDiff.mul(999).div(1000);
 
     const safePricedDiff = safeAdjustedPricedDiff.div(asset.config.volatility_ratio).mul(10000);
 

--- a/src/screens/Borrow/tabledata.tsx
+++ b/src/screens/Borrow/tabledata.tsx
@@ -37,6 +37,7 @@ export const columns = [
         format="reward"
         rewardLayout="horizontal"
         rewards={rowData.borrowRewards}
+        page="borrow"
       />
     ),
   },

--- a/src/screens/Deposit/tabledata.tsx
+++ b/src/screens/Deposit/tabledata.tsx
@@ -25,7 +25,7 @@ export const columns = [
     ),
   },
   {
-    label: <Label name="Rewards" title="Rewards / Day" />,
+    label: <Label name="Rewards" title="Estimated Rewards / Day" />,
     dataKey: "rewards",
     align: "left",
     sortLabelStyle: { minWidth: [90, 90, "auto"] },

--- a/src/screens/Deposit/tabledata.tsx
+++ b/src/screens/Deposit/tabledata.tsx
@@ -37,6 +37,7 @@ export const columns = [
         format="reward"
         rewardLayout="horizontal"
         rewards={rowData.depositRewards}
+        page="deposit"
       />
     ),
   },


### PR DESCRIPTION
- Remove net liquidity APY from the borrowing page
- Show net liquidity APY = 0 when net liquidity is negative 
- Hide scrollbars on firefox
- Add tooltip labels for stats sections
- Add net liquidity pro-rata amount of tokens distributed to each asset
- Show only deposits and borrows on protocol tab
- Remove not farming label, and move the tooltip to “0.00% Net Liquidity” label
- In the banner, under APY, the lables should be colored. Green for positive, yellow for zero, red for negative 